### PR TITLE
build: source various actions from 3pa

### DIFF
--- a/.github/workflows/terraform-pr.yaml
+++ b/.github/workflows/terraform-pr.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: Brightspace/third-party-actions@actions/checkout
 
       - name: Configure AWS Credentials
-        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials-node16
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/terraform-pr.yaml
+++ b/.github/workflows/terraform-pr.yaml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: Brightspace/third-party-actions@actions/checkout
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -62,7 +62,7 @@ jobs:
           terraform plan -no-color
 
       - name: Update Pull Request
-        uses: actions/github-script@v6
+        uses: Brightspace/third-party-actions@actions/github-script
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
         with:


### PR DESCRIPTION
Brightspace/third-party-actions is a mirror of third party github
actions. It gives us a spot to check updates to actions before applying
them, which helps mitigate supply chain attacks. Mirroring them also
prevents breakage should an action be deleted or otherwise become
unavailable.

We've recently updated our GitHub configuration with an allowlist of
non-Brightspace actions in order to better enforce third-party-actions
usage, which we would like to shrink.

This commit updates various action usages (but not necessarily all) to
point to third-party-actions. These were some of the most common
variances, and ones which I believe are non-breaking (either due to
being the same version, or being a compatible version).

Ref: LFT-1553
Ref: https://github.com/Brightspace/third-party-actions-config/issues/881
